### PR TITLE
Fixed type that broke error messages.

### DIFF
--- a/app.js
+++ b/app.js
@@ -29,7 +29,7 @@ beam.use('password', {
 .catch(err => {
 	console.log(err.message);
     if (err.res) {
-        throw new Error('Error connecting to Interactive:' + err.res.body.mesage);
+        throw new Error('Error connecting to Interactive:' + err.res.body.message);
     }
     throw new Error('Error connecting to Interactive', err);
 });


### PR DESCRIPTION
When forwarding an error during the setup chain of the robot, the forwarded error message was read from the error's body with .mesage, which is always undefined. Changed to .message, now it prints what is wrong.